### PR TITLE
Reset the current_user to it's initial state after the current job ha…

### DIFF
--- a/delayed_job_with_user.gemspec
+++ b/delayed_job_with_user.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.summary = "Small wrapper around Delayed::Job to instantiate current_user in Job"
-  spec.version = '1.1.1'
+  spec.version = '1.1.2'
 end

--- a/lib/delayed_job_with_user.rb
+++ b/lib/delayed_job_with_user.rb
@@ -32,6 +32,7 @@ module DelayedJobWithUser
 
     def before(job)
       begin
+        @old_current_user = User.current_user
         User.current_user = User.find(job.started_by)
         time_zone = User.current_user.person.time_zone rescue Time.zone.name
         time_zone_is_valid = time_zone.present? && ActiveSupport::TimeZone.all.include?(ActiveSupport::TimeZone.new(time_zone))
@@ -48,6 +49,7 @@ module DelayedJobWithUser
     end
 
     def after(job)
+      User.current_user = @old_current_user
       self.execute_callbacks(:after, job, nil)
     end
 


### PR DESCRIPTION
…s finished

Issue:
Because of cattr_accessor :current_user,
if we don't reset the current user, it remains in the
worker process and used as a current_user for next job.

Fix:
reset to its initial state in the after hook.

ILAB-22205